### PR TITLE
fix: Fix msedgedriver version detection

### DIFF
--- a/edge.js
+++ b/edge.js
@@ -54,8 +54,8 @@ class EdgeWebDriverInstaller extends WebDriverInstallerBase {
 
     const output = await InstallerUtils.getCommandOutputOrNullIfMissing(
         [outputPath, '--version']);
-    // Output is a string like "MSEdgeDriver 96.0.1054.62 (sha1)\n"
-    return output ? output.trim().split(' ')[1] : null;
+    // Output is a string like "Microsoft Edge WebDriver 108.0.1462.46 ...\n"
+    return output ? output.trim().split(' ')[3] : null;
   }
 
   /**


### PR DESCRIPTION
The version string for msedgedriver has been updated, and our parser needs updating, too.  Otherwise, we reinstall msedgedriver every time, even if we don't need to.