### PR TITLE
fix: Ignore errors executing non-executable drivers

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -59,6 +59,11 @@ class InstallerUtils {
       if (error.code == 'ENOENT') {
         // Command does not exist.
         return null;
+      } else if (error.code == 'EACCES') {  // Missing "s" is not a typo!
+        // Command is not executable.  This can happen after a failed run that
+        // downloads something, but is interrupted before setting its
+        // executable bit.
+        return null;
       } else {
         // Command exists, but failed.
         throw error;


### PR DESCRIPTION
Sometimes WebDriver Installer can be interrupted after downloading, but before setting the executable bits.  This leads to a failure later when checking the WebDriver version.

We should ignore those errors and let WebDriver Installer replace the driver instead.

Closes #22