### PR TITLE
fix: Retry when WebDriver updates are not available yet

### DIFF
--- a/chrome.js
+++ b/chrome.js
@@ -63,7 +63,7 @@ class ChromeWebDriverInstaller extends WebDriverInstallerBase {
    * @return {!Promise<string>}
    */
   async getBestDriverVersion(browserVersion) {
-    const idealMajorVersion = parseInt(browserVersion.split('.')[0]);
+    const idealMajorVersion = parseInt(browserVersion.split('.')[0], 10);
     return await InstallerUtils.fetchVersionUrlWithAutomaticDowngrade(
         idealMajorVersion,
         /* minMajorVersion */ idealMajorVersion - 2,

--- a/chrome.js
+++ b/chrome.js
@@ -63,9 +63,11 @@ class ChromeWebDriverInstaller extends WebDriverInstallerBase {
    * @return {!Promise<string>}
    */
   async getBestDriverVersion(browserVersion) {
-    const majorVersion = browserVersion.split('.')[0];
-    const versionUrl = `${CDN_URL}/LATEST_RELEASE_${majorVersion}`;
-    return await InstallerUtils.fetchVersionUrl(versionUrl);
+    const idealMajorVersion = parseInt(browserVersion.split('.')[0]);
+    return await InstallerUtils.fetchVersionUrlWithAutomaticDowngrade(
+        idealMajorVersion,
+        /* minMajorVersion */ idealMajorVersion - 2,
+        (majorVersion) => `${CDN_URL}/LATEST_RELEASE_${majorVersion}`);
   }
 
   /**

--- a/edge.js
+++ b/edge.js
@@ -63,7 +63,7 @@ class EdgeWebDriverInstaller extends WebDriverInstallerBase {
    * @return {!Promise<string>}
    */
   async getBestDriverVersion(browserVersion) {
-    const majorVersion = browserVersion.split('.')[0];
+    const idealMajorVersion = parseInt(browserVersion.split('.')[0]);
 
     let platform;
     if (os.platform() == 'linux') {
@@ -76,8 +76,15 @@ class EdgeWebDriverInstaller extends WebDriverInstallerBase {
       throw new Error(`Unrecognized platform: ${os.platform()}`);
     }
 
-    const versionUrl = `${CDN_URL}/LATEST_RELEASE_${majorVersion}_${platform}`;
-    return await InstallerUtils.fetchVersionUrl(versionUrl, 'UTF-16LE');
+    const urlFormatter = (majorVersion) => {
+      return `${CDN_URL}/LATEST_RELEASE_${majorVersion}_${platform}`;
+    };
+
+    return await InstallerUtils.fetchVersionUrlWithAutomaticDowngrade(
+        idealMajorVersion,
+        /* minMajorVersion */ idealMajorVersion - 2,
+        urlFormatter,
+        'UTF-16LE');
   }
 
   /**

--- a/edge.js
+++ b/edge.js
@@ -63,7 +63,7 @@ class EdgeWebDriverInstaller extends WebDriverInstallerBase {
    * @return {!Promise<string>}
    */
   async getBestDriverVersion(browserVersion) {
-    const idealMajorVersion = parseInt(browserVersion.split('.')[0]);
+    const idealMajorVersion = parseInt(browserVersion.split('.')[0], 10);
 
     let platform;
     if (os.platform() == 'linux') {


### PR DESCRIPTION
Some WebDriver updates for Chrome and Edge lag behind the corresponding browser releases.  This will automatically retry with the previous 2 releases when a 404 is encountered.

This fixes the failure on Chrome 115 today (ChromeDriver 115 is not out yet).