### PR TITLE
fix: Get the correct binary for Edge on M1 macs

### DIFF
--- a/edge.js
+++ b/edge.js
@@ -98,7 +98,11 @@ class EdgeWebDriverInstaller extends WebDriverInstallerBase {
     if (os.platform() == 'linux') {
       platform = 'linux64';
     } else if (os.platform() == 'darwin') {
-      platform = 'mac64';
+      if (process.arch == 'arm64') {
+        platform = 'mac64_m1';
+      } else {
+        platform = 'mac64';
+      }
     } else if (os.platform() == 'win32') {
       platform = 'win64';
     } else {


### PR DESCRIPTION
Backward compatibility at the OS level was saving us before this, but we should get the more efficient binary that doesn't require any translation/emulation.