### PR TITLE
fix: Revert EdgeDriver 115+ workaround

### DIFF
--- a/edge.js
+++ b/edge.js
@@ -78,17 +78,7 @@ class EdgeWebDriverInstaller extends WebDriverInstallerBase {
       return `${CDN_URL}/LATEST_RELEASE_${majorVersion}_${platform}`;
     };
 
-    let idealMajorVersion = parseInt(browserVersion.split('.')[0], 10);
-
-    // Work around https://github.com/MicrosoftEdge/EdgeWebDriver/issues/102,
-    // in which Linux versions of msedgedriver launch Chrome instead of Edge
-    // starting with version 115.  For now, driver version 114 is working for
-    // Edge 115 on Linux.
-    if (os.platform() == 'linux') {
-      if (idealMajorVersion > 114) {
-        idealMajorVersion = 114;
-      }
-    }
+    const idealMajorVersion = parseInt(browserVersion.split('.')[0], 10);
 
     return await InstallerUtils.fetchVersionUrlWithAutomaticDowngrade(
         idealMajorVersion,


### PR DESCRIPTION
For a better workaround, specify the path to the Edge binary in your capabilities request with:

"ms:edgeOptions": {"binary": "/usr/bin/microsoft-edge"}

See also https://github.com/MicrosoftEdge/EdgeWebDriver/issues/102#issuecomment-1710724173