### PR TITLE
ci: Update node and fix test job on MacOS

### DIFF
--- a/.github/workflows/test-gha.yaml
+++ b/.github/workflows/test-gha.yaml
@@ -34,6 +34,12 @@ jobs:
           node-version: 22
           registry-url: 'https://registry.npmjs.org'
 
+      # Firefox and Edge might be missing on Mac CI images.
+      - name: 'Install Firefox & Edge on Mac'
+        timeout-minutes: 5
+        if: matrix.os == 'macos-latest'
+        run: brew install --cask firefox microsoft-edge
+
       - run: npm ci
 
       - run: node ./main.js

--- a/.github/workflows/test-gha.yaml
+++ b/.github/workflows/test-gha.yaml
@@ -29,9 +29,9 @@ jobs:
         with:
           ref: ${{ github.ref }}
 
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v4
         with:
-          node-version: 12
+          node-version: 22
           registry-url: 'https://registry.npmjs.org'
 
       - run: npm ci


### PR DESCRIPTION
Updates node action and used node version to current LTS.
Installs Firefox and Edge on Mac to fix test workflow.