### PR TITLE
fix: Fix msedgedriver install

### DIFF
--- a/edge.js
+++ b/edge.js
@@ -10,7 +10,7 @@ const {InstallerUtils} = require('./utils.js');
 const os = require('os');
 const path = require('path');
 
-const CDN_URL = 'https://msedgedriver.azureedge.net/';
+const CDN_URL = 'https://msedgedriver.microsoft.com/';
 
 /**
  * An installer for msedgedriver for desktop Edge.

--- a/utils.js
+++ b/utils.js
@@ -264,7 +264,7 @@ class InstallerUtils {
       try {
         return await InstallerUtils.fetchVersionUrl(versionUrl, encoding);
       } catch (error) {
-        if (error.cause.status != 404) {
+        if (error.cause?.status != 404) {
           // Any unexpected error (other than HTTP 404) is thrown immediately.
           throw error;
         }


### PR DESCRIPTION
1. Update msedgedriver CDN URL, which recently changed
2. Fix crash reading exception when DNS fails instead of HTTP failure