### PR TITLE
fix(ci): Stop using NPM token, use trusted publishing

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,9 +1,12 @@
+name: release-please
+
 on:
   push:
     branches:
       - main
 
-name: release-please
+permissions:
+  id-token: write  # Required for OIDC
 
 jobs:
   release-please:
@@ -40,8 +43,6 @@ jobs:
         if: ${{ steps.release.outputs.release_created }}
 
       - run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
         if: ${{ steps.release.outputs.release_created }}
 
       - run: npm pack


### PR DESCRIPTION
See also https://docs.npmjs.com/trusted-publishers