### PR TITLE
fix(ci): More robust release workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,4 +1,4 @@
-name: release-please
+name: Release
 
 on:
   push:
@@ -6,12 +6,13 @@ on:
       - main
 
 jobs:
-  release-please:
+  release:
     runs-on: ubuntu-latest
+    outputs:
+      tag_name: ${{ steps.release.outputs.tag_name }}
+      release_created: ${{ steps.release.outputs.release_created }}
 
     permissions:
-      # Required for OIDC ("trusted publishing")
-      id-token: write
       # Write to "contents" is needed to create a release
       contents: write
       # Write to pull-requests is needed to create and update the release PR
@@ -24,44 +25,46 @@ jobs:
         with:
           release-type: node
 
+  npm:
+    runs-on: ubuntu-latest
+    needs: release
+    if: needs.release.outputs.release_created
+
+    permissions:
+      # Required for OIDC ("trusted publishing")
+      id-token: write
+
+    steps:
       # The logic below handles npm publication.  Each step is conditional on a
       # release having been created by someone merging the release PR.
       - uses: actions/checkout@v4
         with:
-          ref: refs/tags/${{ steps.release.outputs.tag_name }}
+          ref: refs/tags/${{ needs.release.outputs.tag_name }}
           persist-credentials: false
-        if: ${{ steps.release.outputs.release_created }}
 
       - uses: actions/setup-node@v4
         with:
           # NOTE: OIDC fails with node less than 24.
           node-version: 24
           registry-url: 'https://registry.npmjs.org'
-        if: ${{ steps.release.outputs.release_created }}
 
       # NOTE: OIDC fails with npm less than 11.5.1.
       - name: Update npm
         run: sudo npm install -g npm@11.7
-        if: ${{ steps.release.outputs.release_created }}
 
       - run: npm ci
-        if: ${{ steps.release.outputs.release_created }}
 
       # NOTE: OIDC fails if the repository URL doesn't match package.json.
       - run: npm pkg set repository.url=https://github.com/${{ github.repository }}
-        if: ${{ steps.release.outputs.release_created }}
 
       # NOTE: --access public is required for scoped forks.
       - run: npm publish --access public
-        if: ${{ steps.release.outputs.release_created }}
 
       # Stores the file name into the file "tarball" (unpredictable for forks).
       - run: npm pack > tarball
-        if: ${{ steps.release.outputs.release_created }}
 
       - name: Attach files to release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         # Reads the file name from the file "tarball".
-        run: gh release upload --clobber "${{ steps.release.outputs.tag_name }}" "$(cat tarball)"
-        if: ${{ steps.release.outputs.release_created }}
+        run: gh release upload --clobber "${{ needs.release.outputs.tag_name }}" "$(cat tarball)"


### PR DESCRIPTION
By splitting the workflow into two jobs, the npm job can fail and be rerun separately from release-please.

Without this, a rerun would include release-please, whose outputs would change, bypassing the npm steps of the single job.

This is a follow-on to work done for trusted publishing (shaka-project/shaka-player#9132)