### PR TITLE
fix(ci): Fix tarball upload permissions

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -33,6 +33,8 @@ jobs:
     permissions:
       # Required for OIDC ("trusted publishing")
       id-token: write
+      # Write to "contents" is needed to attach files to the release
+      contents: write
 
     steps:
       # The logic below handles npm publication.  Each step is conditional on a


### PR DESCRIPTION
The last release, 1.3.1, failed to attach a tarball to the release due to a mission permission in the final job.

Follow-up to splitting the workflow as described in shaka-project/shaka-github-tools#56