### PR TITLE
fix: Read the Windows registry via PowerShell instead of WMI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "node-fetch": "^2.6.7",
-        "regedit": "^5.0.0",
         "tar-stream": "^2.2.0",
         "yauzl": "^3.2.1"
       },
@@ -78,27 +77,6 @@
         "node": "*"
       }
     },
-    "node_modules/core-util-is": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
-    },
-    "node_modules/debug": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/end-of-stream": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
@@ -131,25 +109,10 @@
         }
       ]
     },
-    "node_modules/if-async": {
-      "version": "3.7.4",
-      "resolved": "https://registry.npmjs.org/if-async/-/if-async-3.7.4.tgz",
-      "integrity": "sha1-VYaN6wCT08Z79xZudFNT+5vLIaI="
-    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-    },
-    "node_modules/isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-    },
-    "node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/node-fetch": {
       "version": "2.6.7",
@@ -196,17 +159,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/regedit": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/regedit/-/regedit-5.0.0.tgz",
-      "integrity": "sha512-4uSqj6Injwy5TPtXlE+1F/v2lOW/bMfCqNIAXyib4aG1ZwacG69oyK/yb6EF8KQRMhz7YINxkD+/HHc6i7YJtA==",
-      "dependencies": {
-        "debug": "^4.1.0",
-        "if-async": "^3.7.4",
-        "stream-slicer": "0.0.6",
-        "through2": "^0.6.3"
-      }
-    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -225,11 +177,6 @@
           "url": "https://feross.org/support"
         }
       ]
-    },
-    "node_modules/stream-slicer": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/stream-slicer/-/stream-slicer-0.0.6.tgz",
-      "integrity": "sha1-+GsqxcJEC3oKh7cfM2ZcB4gEYTg="
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
@@ -253,31 +200,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/through2": {
-      "version": "0.6.5",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-      "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-      "dependencies": {
-        "readable-stream": ">=1.0.33-1 <1.1.0-0",
-        "xtend": ">=4.0.0 <4.1.0-0"
-      }
-    },
-    "node_modules/through2/node_modules/readable-stream": {
-      "version": "1.0.34",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-      "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
-        "isarray": "0.0.1",
-        "string_decoder": "~0.10.x"
-      }
-    },
-    "node_modules/through2/node_modules/string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
     },
     "node_modules/tr46": {
       "version": "0.0.3",
@@ -307,14 +229,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-    },
-    "node_modules/xtend": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-      "engines": {
-        "node": ">=0.4"
-      }
     },
     "node_modules/yauzl": {
       "version": "3.2.1",
@@ -359,19 +273,6 @@
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
     },
-    "core-util-is": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
-    },
-    "debug": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
-      "requires": {
-        "ms": "2.1.2"
-      }
-    },
     "end-of-stream": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
@@ -390,25 +291,10 @@
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
     },
-    "if-async": {
-      "version": "3.7.4",
-      "resolved": "https://registry.npmjs.org/if-async/-/if-async-3.7.4.tgz",
-      "integrity": "sha1-VYaN6wCT08Z79xZudFNT+5vLIaI="
-    },
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-    },
-    "isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-    },
-    "ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node-fetch": {
       "version": "2.6.7",
@@ -441,26 +327,10 @@
         "util-deprecate": "^1.0.1"
       }
     },
-    "regedit": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/regedit/-/regedit-5.0.0.tgz",
-      "integrity": "sha512-4uSqj6Injwy5TPtXlE+1F/v2lOW/bMfCqNIAXyib4aG1ZwacG69oyK/yb6EF8KQRMhz7YINxkD+/HHc6i7YJtA==",
-      "requires": {
-        "debug": "^4.1.0",
-        "if-async": "^3.7.4",
-        "stream-slicer": "0.0.6",
-        "through2": "^0.6.3"
-      }
-    },
     "safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
-    },
-    "stream-slicer": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/stream-slicer/-/stream-slicer-0.0.6.tgz",
-      "integrity": "sha1-+GsqxcJEC3oKh7cfM2ZcB4gEYTg="
     },
     "string_decoder": {
       "version": "1.3.0",
@@ -480,33 +350,6 @@
         "fs-constants": "^1.0.0",
         "inherits": "^2.0.3",
         "readable-stream": "^3.1.1"
-      }
-    },
-    "through2": {
-      "version": "0.6.5",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-      "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-      "requires": {
-        "readable-stream": ">=1.0.33-1 <1.1.0-0",
-        "xtend": ">=4.0.0 <4.1.0-0"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-        }
       }
     },
     "tr46": {
@@ -537,11 +380,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-    },
-    "xtend": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
     },
     "yauzl": {
       "version": "3.2.1",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
   "author": "Joey Parrish <joeyparrish@google.com>",
   "dependencies": {
     "node-fetch": "^2.6.7",
-    "regedit": "^5.0.0",
     "tar-stream": "^2.2.0",
     "yauzl": "^3.2.1"
   },

--- a/utils.js
+++ b/utils.js
@@ -10,14 +10,12 @@ const fs = require('fs');
 const fsPromises = require('fs').promises;
 const os = require('os');
 const path = require('path');
-const regedit = require('regedit');
 const stream = require('stream');
 const tar = require('tar-stream');
 const util = require('util');
 const yauzl = require('yauzl');
 const zlib = require('zlib');
 
-const regQuery = util.promisify(regedit.list);
 const execFile = util.promisify(childProcess.execFile);
 const pipeline = util.promisify(stream.pipeline);
 const zipFromBuffer = util.promisify(yauzl.fromBuffer);
@@ -88,10 +86,14 @@ class InstallerUtils {
   }
 
   /**
-   * Get a version number from the Windows registry.
+   * Read a value from the Windows registry.  Returns null if not found.
    *
-   * @param {string} regPath
-   * @param {string} key
+   * Uses PowerShell's registry provider.  We avoid WMI-based registry access
+   * (as used by some libraries), which can hang indefinitely when a machine's
+   * WMI provider is unhealthy and would block driver installation.
+   *
+   * @param {string} regPath  A registry path like "HKLM\\Software\\..."
+   * @param {string} key  A value name, or "" for the key's default value.
    * @return {!Promise<?string>}
    */
   static async getWindowsRegistryVersion(regPath, key) {
@@ -99,17 +101,31 @@ class InstallerUtils {
       return null;
     }
 
-    // Try the 64-bit registry first, then fall back to the 32-bit registry.
-    // Necessary values could be in either location.
-    let result = await regQuery(regPath, '64');
-    if (!result[regPath].exists || !result[regPath].values[key]) {
-      result = await regQuery(regPath, '32');
-    }
-    if (!result[regPath].exists || !result[regPath].values[key]) {
-      return null;
+    // Read the native view first, then the 32-bit (WOW6432Node) view, since the
+    // value could be in either.
+    const psPath = regPath.replace(/^HKLM\\/i, 'HKLM:\\');
+    const psPaths = [psPath];
+    const wowPath = psPath.replace(/^(HKLM:\\Software\\)/i, '$1WOW6432Node\\');
+    if (wowPath != psPath) {
+      psPaths.push(wowPath);
     }
 
-    return result[regPath].values[key].value;
+    // PowerShell exposes a key's default value under the name "(default)".
+    const valueName = key === '' ? '(default)' : key;
+
+    for (const psRegPath of psPaths) {
+      const result = await InstallerUtils.runCommand([
+        'powershell',
+        `(Get-ItemProperty -LiteralPath '${psRegPath}' ` +
+            `-ErrorAction SilentlyContinue).'${valueName}'`,
+      ]);
+      const value = result.stdout.trim();
+      if (value) {
+        return value;
+      }
+    }
+
+    return null;
   }
 
   /**


### PR DESCRIPTION
getWindowsExeVersion resolved a browser's full path by reading the registry through the 'regedit' package, which reaches the registry via a WMI provider.  When a machine's WMI provider is unhealthy, that call hangs indefinitely and blocks driver installation.  Read the value through PowerShell's registry provider instead, which does not depend on WMI, and drop the regedit dependency.